### PR TITLE
Some Small Fixes

### DIFF
--- a/src/main/java/grondag/frex/impl/event/BlockStateRendererImpl.java
+++ b/src/main/java/grondag/frex/impl/event/BlockStateRendererImpl.java
@@ -41,6 +41,10 @@ public class BlockStateRendererImpl implements BlockStateRenderer {
 	@Override
 	public void bake(BlockPos pos, BlockState state) {
 		final BakedModel model = blockRenderManager.getModel(state);
+
+		matrixStack.push();
+		matrixStack.translate(pos.getX() & 15, pos.getY() & 15, pos.getZ() & 15);
 		((AccessChunkRendererRegion) chunkRendererRegion).fabric_getRenderer().tesselateBlock(state, pos, model, matrixStack);
+		matrixStack.pop();
 	}
 }

--- a/src/main/java/grondag/frex/impl/event/ChunkRenderConditionContext.java
+++ b/src/main/java/grondag/frex/impl/event/ChunkRenderConditionContext.java
@@ -36,7 +36,7 @@ public class ChunkRenderConditionContext implements RenderRegionContext {
 
 	@Override
 	public BlockPos origin() {
-		return null;
+		return this.origin;
 	}
 
 	public void prepare(int x, int y, int z, BlockRenderView blockView) {

--- a/src/main/java/grondag/frex/impl/event/RenderRegionBakeListenerImpl.java
+++ b/src/main/java/grondag/frex/impl/event/RenderRegionBakeListenerImpl.java
@@ -53,8 +53,6 @@ public class RenderRegionBakeListenerImpl {
 	}
 
 	private static final Event<BakeHandler> EVENT = EventFactory.createArrayBacked(BakeHandler.class, listeners -> (context, list) -> {
-		list.clear();
-
 		for (final BakeHandler handler : listeners) {
 			handler.handle(context, list);
 		}
@@ -65,6 +63,7 @@ public class RenderRegionBakeListenerImpl {
 	}
 
 	public static void prepareInvocations(RenderRegionContext context, List<RenderRegionBakeListener> list) {
+		list.clear();
 		EVENT.invoker().handle(context, list);
 	}
 }


### PR DESCRIPTION
- Fixes a NullPointerException
- Moves clear from the invoker factory to `prepareInvocations` to avoid infinitely growing list
- Translates the matrix so that blocks are rendered in the correct location

More work needs to be done before this is working properly. Right now, only the first few chunk sections to be rendered actually have things baked into them.