### PR TITLE
Flawless Frames feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 group=grondag
 mod_name=frex
-frex_version=5.3
+frex_version=5.4
 
 mc_tag=mc117
 minecraft_version=1.17.1

--- a/src/main/java/grondag/frex/Frex.java
+++ b/src/main/java/grondag/frex/Frex.java
@@ -27,6 +27,7 @@ import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 
+import grondag.frex.impl.config.FlawlessFramesImpl;
 import grondag.frex.impl.fluid.FluidQuadSupplierImpl;
 import grondag.frex.impl.light.ItemLightLoader;
 import grondag.frex.impl.material.MaterialMapLoader;
@@ -62,6 +63,8 @@ public class Frex implements ClientModInitializer {
 
 		FabricLoader.getInstance().getEntrypoints("frex", FrexInitializer.class).forEach(
 			api -> api.onInitalizeFrex());
+
+		FlawlessFramesImpl.onClientInitialization();
 
 		InvalidateRenderStateCallback.EVENT.register(FluidQuadSupplierImpl::reload);
 	}

--- a/src/main/java/grondag/frex/api/config/FlawlessFrames.java
+++ b/src/main/java/grondag/frex/api/config/FlawlessFrames.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2019, 2020 grondag
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License.  You may obtain a copy
+ *  of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package grondag.frex.api.config;
+
+import grondag.frex.impl.config.FlawlessFramesImpl;
+
+/**
+ * FREX implementation of an entry point mods like ReplayMod can use to signal the
+ * renderer that rendering quality should be favored over speed because output is being
+ * automatically recorded. If a renderer is playing loose with some visual elements
+ * to achieve interactive frame rates it should try to disable those if it will give
+ * a noticeable boost to quality.
+ *
+ * <p>At a minimum, the renderer should ensure that terrain iteration blocks the main
+ * render thread until the entire visible set of chunk sections are determined and all
+ * visible chunk sections have been built and can be rendered in the frame.
+ *
+ * <p>While this API is defined as part of FREX, it uses standard Java interfaces so that
+ * it can be implemented and consumed without reference to any FREX library or any other
+ * mod dependency. This is done to facilitate adoption by renderers that do not implement
+ * FREX and to spare mods that do not use other FREX features from including it.
+ *
+ * <p>This interface and it's implementation is provided as a convenience for FREX renderers.
+ * Non-FREX renderers can copy the relevant code from FREX or create their own implementation as desired.
+ *
+ * <p>Mods that want to request control of this feature should implement the {@code frex_flawless_frames}
+ * entry point, as illustrated below. The entry point class must implement
+ * {@code Consumer<Function<String, Consumer<Boolean>>>}.
+ *
+ * <p><pre>
+ * "entrypoints": {
+ *    "frex_flawless_frames": [ "yourorg.yourmod.yourpackage.MyConsumer" ]
+ * }</pre>
+ *
+ * <p>The renderer should ensure every mod that declares this end point should receive exactly
+ * one call to provided consumers. (For renderers using FREX, the library handles this
+ * automatically.)
+ *
+ * <p>When an end point is invoked, the mod consumer will receive a {@code Function<String, Consumer<Boolean>>}
+ * instance.  The string name passed in to this function is meant to facilitate logging and debugging
+ * of activation within the renderer when multiple mods may be use the end point. The resulting
+ * consumer can then be used at any time to activate or deactivate this feature.
+ *
+ * <p>The contract for usage of the activation consumer is as follows:
+ * <ul><li>Must be called only from the render thread.
+ * <li>Calls are idempotent - setting true or false multiple times in succession has the same
+ * outcome as calling once.</ul>
+ *
+ * <p>The renderer should activate the feature when one or more consumers have requested it
+ * and deactivate the feature when no consumers have activated it.  FREX renderers can use
+ * {@link #isActive()} to query the currently effective state.
+ */
+public interface FlawlessFrames {
+	/**
+	 * Queries the effective status of this feature.
+	 * @return True if any mod has requested activation, false otherwise.
+	 */
+	static boolean isActive() {
+		return FlawlessFramesImpl.isActive();
+	}
+
+	/**
+	 * Enables or disables logging of feature activation as a diagnostic aid.
+	 */
+	static void enableTrace(boolean enable) {
+		FlawlessFramesImpl.enableTrace(enable);
+	}
+}

--- a/src/main/java/grondag/frex/api/config/FlawlessFrames.java
+++ b/src/main/java/grondag/frex/api/config/FlawlessFrames.java
@@ -60,8 +60,9 @@ import grondag.frex.impl.config.FlawlessFramesImpl;
  * consumer, but it can be any thread.)
  * <li>Calls are idempotent - setting true or false multiple times in succession has the same
  * outcome as calling once.
- * <li>The renderer will check the current status at the start of a frame and that status
- * will be effective for the whole frame.
+ * <li>The renderer will check the current status at least once every frame, and most
+ * implementations will probably check at the start of the frame.  While an implementation may
+ * check for changes at any time during a frame, it isn't required to change behavior until the next.
  * <li>Because of the above conditions, consumers needing precise control of frames should
  * change status on the render thread before the start of the next frame.</ul>
  *

--- a/src/main/java/grondag/frex/api/config/FlawlessFrames.java
+++ b/src/main/java/grondag/frex/api/config/FlawlessFrames.java
@@ -19,11 +19,11 @@ package grondag.frex.api.config;
 import grondag.frex.impl.config.FlawlessFramesImpl;
 
 /**
- * FREX implementation of an entry point mods like ReplayMod can use to signal the
+ * FREX renderer access for an entry point mods like ReplayMod can use to signal the
  * renderer that rendering quality should be favored over speed because output is being
  * automatically recorded. If a renderer is playing loose with some visual elements
- * to achieve interactive frame rates it should try to disable those if it will give
- * a noticeable boost to quality.
+ * to achieve interactive frame rates it should try to disable those measures if it will
+ * give a noticeable boost to quality.
  *
  * <p>At a minimum, the renderer should ensure that terrain iteration blocks the main
  * render thread until the entire visible set of chunk sections are determined and all
@@ -34,7 +34,7 @@ import grondag.frex.impl.config.FlawlessFramesImpl;
  * mod dependency. This is done to facilitate adoption by renderers that do not implement
  * FREX and to spare mods that do not use other FREX features from including it.
  *
- * <p>This interface and it's implementation is provided as a convenience for FREX renderers.
+ * <p>This interface and it's implementation are provided as a convenience for FREX renderers.
  * Non-FREX renderers can copy the relevant code from FREX or create their own implementation as desired.
  *
  * <p>Mods that want to request control of this feature should implement the {@code frex_flawless_frames}
@@ -46,23 +46,28 @@ import grondag.frex.impl.config.FlawlessFramesImpl;
  *    "frex_flawless_frames": [ "yourorg.yourmod.yourpackage.MyConsumer" ]
  * }</pre>
  *
- * <p>The renderer should ensure every mod that declares this end point should receive exactly
- * one call to provided consumers. (For renderers using FREX, the library handles this
- * automatically.)
+ * <p>Renderer implementations should ensure every mod that declares this end point receives exactly
+ * one call to provided consumers. (For renderers using FREX, the provided implementation satisfies
+ * this guarantee.)
  *
  * <p>When an end point is invoked, the mod consumer will receive a {@code Function<String, Consumer<Boolean>>}
  * instance.  The string name passed in to this function is meant to facilitate logging and debugging
- * of activation within the renderer when multiple mods may be use the end point. The resulting
+ * of activation within the renderer when multiple mods may be using the end point. The resulting
  * consumer can then be used at any time to activate or deactivate this feature.
  *
  * <p>The contract for usage of the activation consumer is as follows:
- * <ul><li>Must be called only from the render thread.
+ * <ul><li>Calls are thread-safe but not reentrant. (Only one thread should call a given
+ * consumer, but it can be any thread.)
  * <li>Calls are idempotent - setting true or false multiple times in succession has the same
- * outcome as calling once.</ul>
+ * outcome as calling once.
+ * <li>The renderer will check the current status at the start of a frame and that status
+ * will be effective for the whole frame.
+ * <li>Because of the above conditions, consumers needing precise control of frames should
+ * change status on the render thread before the start of the next frame.</ul>
  *
- * <p>The renderer should activate the feature when one or more consumers have requested it
- * and deactivate the feature when no consumers have activated it.  FREX renderers can use
- * {@link #isActive()} to query the currently effective state.
+ * <p>The feature will be active when one or more consumers have requested it and inactive
+ * when no consumers have activated it.  FREX renderers can use {@link #isActive()} to query
+ * the currently effective state.
  */
 public interface FlawlessFrames {
 	/**

--- a/src/main/java/grondag/frex/impl/config/FlawlessFramesImpl.java
+++ b/src/main/java/grondag/frex/impl/config/FlawlessFramesImpl.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2019, 2020 grondag
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License.  You may obtain a copy
+ *  of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package grondag.frex.impl.config;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
+import com.mojang.blaze3d.systems.RenderSystem;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+import grondag.frex.Frex;
+
+public class FlawlessFramesImpl {
+	private static class Controller implements Consumer<Boolean> {
+		final String owner;
+		boolean isActive = false;
+
+		private Controller(String owner) {
+			this.owner = owner;
+		}
+
+		@Override
+		public String toString() {
+			return owner;
+		}
+
+		@Override
+		public void accept(Boolean isActive) {
+			Preconditions.checkState(RenderSystem.isOnRenderThread(), "Flawless Frames must be controlled from the render thread.");
+
+			if (this.isActive != isActive) {
+				if (this.isActive) {
+					ACTIVE.remove(this);
+					if (enableTrace) Frex.LOG.info("Deactivating Flawless Frames at request of " + owner);
+				} else {
+					ACTIVE.add(this);
+					if (enableTrace) Frex.LOG.info("Activating Flawless Frames at request of " + owner);
+				}
+
+				this.isActive = isActive;
+
+				if (enableTrace) {
+					Frex.LOG.info("Flawless Frames current status is " + isActive());
+					if (isActive()) Frex.LOG.info("Current active controllers are: " + ACTIVE.toString());
+				}
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public static void onClientInitialization() {
+		final Function<String, Consumer<Boolean>> provider = Controller::new;
+
+		FabricLoader.getInstance().getEntrypoints("frex_flawless_frames", Consumer.class).forEach(
+				api -> api.accept(provider));
+	}
+
+	private static final Set<Controller> ACTIVE = Collections.newSetFromMap(new IdentityHashMap<Controller, Boolean>());
+	private static boolean enableTrace = false;
+
+	public static boolean isActive() {
+		return !ACTIVE.isEmpty();
+	}
+
+	public static void enableTrace(boolean enable) {
+		enableTrace = enable;
+	}
+}

--- a/src/main/java/grondag/frex/impl/config/FlawlessFramesImpl.java
+++ b/src/main/java/grondag/frex/impl/config/FlawlessFramesImpl.java
@@ -22,9 +22,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.google.common.base.Preconditions;
-import com.mojang.blaze3d.systems.RenderSystem;
-
 import net.fabricmc.loader.api.FabricLoader;
 
 import grondag.frex.Frex;
@@ -45,22 +42,22 @@ public class FlawlessFramesImpl {
 
 		@Override
 		public void accept(Boolean isActive) {
-			Preconditions.checkState(RenderSystem.isOnRenderThread(), "Flawless Frames must be controlled from the render thread.");
-
 			if (this.isActive != isActive) {
-				if (this.isActive) {
-					ACTIVE.remove(this);
-					if (enableTrace) Frex.LOG.info("Deactivating Flawless Frames at request of " + owner);
-				} else {
-					ACTIVE.add(this);
-					if (enableTrace) Frex.LOG.info("Activating Flawless Frames at request of " + owner);
-				}
+				synchronized (ACTIVE) {
+					if (this.isActive) {
+						ACTIVE.remove(this);
+						if (enableTrace) Frex.LOG.info("Deactivating Flawless Frames at request of " + owner);
+					} else {
+						ACTIVE.add(this);
+						if (enableTrace) Frex.LOG.info("Activating Flawless Frames at request of " + owner);
+					}
 
-				this.isActive = isActive;
+					this.isActive = isActive;
 
-				if (enableTrace) {
-					Frex.LOG.info("Flawless Frames current status is " + isActive());
-					if (isActive()) Frex.LOG.info("Current active controllers are: " + ACTIVE.toString());
+					if (enableTrace) {
+						Frex.LOG.info("Flawless Frames current status is " + isActive());
+						if (isActive()) Frex.LOG.info("Current active controllers are: " + ACTIVE.toString());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Addresses https://github.com/grondag/canvas/issues/282

Pasting relevant javadoc here for convenience.

```java
/**
 * FREX renderer access for an entry point mods like ReplayMod can use to signal the
 * renderer that rendering quality should be favored over speed because output is being
 * automatically recorded. If a renderer is playing loose with some visual elements
 * to achieve interactive frame rates it should try to disable those measures if it will
 * give a noticeable boost to quality.
 *
 * <p>At a minimum, the renderer should ensure that terrain iteration blocks the main
 * render thread until the entire visible set of chunk sections are determined and all
 * visible chunk sections have been built and can be rendered in the frame.
 *
 * <p>While this API is defined as part of FREX, it uses standard Java interfaces so that
 * it can be implemented and consumed without reference to any FREX library or any other
 * mod dependency. This is done to facilitate adoption by renderers that do not implement
 * FREX and to spare mods that do not use other FREX features from including it.
 *
 * <p>This interface and it's implementation are provided as a convenience for FREX renderers.
 * Non-FREX renderers can copy the relevant code from FREX or create their own implementation as desired.
 *
 * <p>Mods that want to request control of this feature should implement the {@code frex_flawless_frames}
 * entry point, as illustrated below. The entry point class must implement
 * {@code Consumer<Function<String, Consumer<Boolean>>>}.
 *
 * <p><pre>
 * "entrypoints": {
 *    "frex_flawless_frames": [ "yourorg.yourmod.yourpackage.MyConsumer" ]
 * }</pre>
 *
 * <p>Renderer implementations should ensure every mod that declares this end point receives exactly
 * one call to provided consumers. (For renderers using FREX, the provided implementation satisfies
 * this guarantee.)
 *
 * <p>When an end point is invoked, the mod consumer will receive a {@code Function<String, Consumer<Boolean>>}
 * instance.  The string name passed in to this function is meant to facilitate logging and debugging
 * of activation within the renderer when multiple mods may be using the end point. The resulting
 * consumer can then be used at any time to activate or deactivate this feature.
 *
 * <p>The contract for usage of the activation consumer is as follows:
 * <ul><li>Calls are thread-safe but not reentrant. (Only one thread should call a given
 * consumer, but it can be any thread.)
 * <li>Calls are idempotent - setting true or false multiple times in succession has the same
 * outcome as calling once.
 * <li>The renderer will check the current status at the start of a frame and that status
 * will be effective for the whole frame.
 * <li>Because of the above conditions, consumers needing precise control of frames should
 * change status on the render thread before the start of the next frame.</ul>
 *
 * <p>The feature will be active when one or more consumers have requested it and inactive
 * when no consumers have activated it.  FREX renderers can use {@link #isActive()} to query
 * the currently effective state.
 */
 ```